### PR TITLE
Spread availability to not be a copy not direct manipulation

### DIFF
--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -13,15 +13,19 @@ import { timeOptions } from '../utils/data'
  * @returns new consolidate availability (array)
  */
 export const consolidateAvailability = availability => {
-  for (let i = 1; i < availability.length; i++) {
-    const timeA = availability[i][0]
-    const timeB = availability[i - 1][1]
+  let consolidatedAvail = [...availability]
+  for (let i = 1; i < consolidatedAvail.length; i++) {
+    const timeA = consolidatedAvail[i][0]
+    const timeB = consolidatedAvail[i - 1][1]
     if (timeOptions.indexOf(timeA) <= timeOptions.indexOf(timeB)) {
-      availability[i - 1] = [availability[i - 1][0], availability[i][1]]
-      availability.splice(i, 1)
+      consolidatedAvail[i - 1] = [
+        consolidatedAvail[i - 1][0],
+        consolidatedAvail[i][1],
+      ]
+      consolidatedAvail.splice(i, 1)
     }
   }
-  return availability
+  return consolidatedAvail
 }
 
 /**


### PR DESCRIPTION
This PR fixes the bug where rendering a users consolidated availability would throw an error.

The new consolidatedAvailability was directly referencing a user's availability rather than referencing a copy of it.

Tested on localhost and this change fixes the bug