### PR TITLE
added missing closing bracket in projectSlice file

### DIFF
--- a/src/utils/redux/slices/projectSlice.ts
+++ b/src/utils/redux/slices/projectSlice.ts
@@ -75,6 +75,7 @@ const projectSlice = createSlice({
     },
     setProjectFailure: state => {
       state.loading = false
+    },
     renderProjectPortal: state => {
       state.projectPortal.renderProjectPortal =
         !state.projectPortal.renderProjectPortal
@@ -111,8 +112,8 @@ export const {
   setProjectStart,
   setProjectSuccess,
   setProjectFailure,
-  renderProjectPortal, 
-  closeProjectPortal
+  renderProjectPortal,
+  closeProjectPortal,
 } = projectSlice.actions
 
 export default projectSlice.reducer


### PR DESCRIPTION
QUICK FIX: Due to a merge into the Dev env created a bug where pulling the dev to ur branch you will see a bunch of errors which are coming from the projectSlice file where the reducer called "setProjectFailure" is missing a closing "}," between lines 77-78 
