### PR TITLE
BUG-FIX: Add project helpers to export index

### DIFF
--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './calendarHelpers'
 export * from './stateHelpers'
 export * from './routeHelpers'
+export * from './projectHelpers'


### PR DESCRIPTION
`Calendar/MeetingModal/SelectAttendees` was throwing `TS2305: Module '"utils/helpers"' has no exported member 'removeAuthUserFromList'` because the new `projectHelpers` util file wasn't being exported from the utils index.

This PR exports the projectHelpers utils from index to eliminate that error