### PR TITLE
Add safeguards for timezones outside of anticipated time zone options

### DIFF
--- a/src/screens/Calendar/EditAvailability.tsx
+++ b/src/screens/Calendar/EditAvailability.tsx
@@ -12,7 +12,6 @@ import {
   utcToBootcamprTimezoneMap,
   bootcamprTimezoneToUTCMap,
 } from 'utils/data/timeZoneConstants'
-import { guessUserTimezone } from 'utils/helpers/availabilityHelpers'
 
 export const EditAvailability = () => {
   const dispatch = useAppDispatch()
@@ -30,17 +29,6 @@ export const EditAvailability = () => {
   useEffect(() => {
     const userFriendlyTimezone = utcToBootcamprTimezoneMap[userTimezoneInUTC]
     setUxUserTimezone(userFriendlyTimezone)
-
-    // Placeholder to eventually handle when user's stored TZ does not match DayJS identified local TZ for user
-    const userTimezoneGuess = guessUserTimezone()
-
-    if (userTimezoneGuess.utc !== userTimezoneInUTC) {
-      console.log(
-        "User's stored timezone does not match detected local timezone"
-      )
-    } else {
-      console.log("User's stored timezone matches our local guess")
-    }
   }, [])
 
   return (

--- a/src/screens/Onboarding/SetupAvailability.tsx
+++ b/src/screens/Onboarding/SetupAvailability.tsx
@@ -41,7 +41,10 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
       userFriendlyTZ = utcToBootcamprTimezoneMap[storedUserTZinUTC]
     } else {
       const userTZguess = guessUserTimezone()
-      userFriendlyTZ = userTZguess.userFriendlyTZ
+
+      userFriendlyTZ = userFriendlyTZ
+        ? userTZguess.userFriendlyTZ
+        : Timezones.ET
     }
     setUxUserTimezone(userFriendlyTZ)
   }, [])

--- a/src/utils/helpers/availabilityHelpers.ts
+++ b/src/utils/helpers/availabilityHelpers.ts
@@ -17,8 +17,19 @@ import {
 export const guessUserTimezone = () => {
   const userTZ = dayjs.tz.guess()
 
-  const utc = dayJSformattedTZdata[userTZ].utc
-  const userFriendlyTZ = utcToBootcamprTimezoneMap[utc]
+  if (
+    userTZ &&
+    dayJSformattedTZdata[userTZ] &&
+    dayJSformattedTZdata[userTZ].utc
+  ) {
+    const utc = dayJSformattedTZdata[userTZ].utc
+    const userFriendlyTZ = utcToBootcamprTimezoneMap[utc]
 
-  return { utc, userFriendlyTZ }
+    return {
+      utc,
+      userFriendlyTZ,
+    }
+  } else {
+    return undefined
+  }
 }


### PR DESCRIPTION
If a user's guessed timezone was outside of our expected options, an uncaught error was thrown and the Availability component would not render.

This PR safeguards the guess user timezone logic to default back to Eastern if a user has an unexpected timezone.