### PR TITLE
bugfix/BD-694-sign-up-opens-new-tab

### DIFF
--- a/src/layout/Nav/Nav.tsx
+++ b/src/layout/Nav/Nav.tsx
@@ -145,7 +145,12 @@ const UnauthorizedNavLinks = () => (
       </Link>
     </div>
     <div>
-      <Link className='sign-up' to='/sign-up'>
+      <Link
+        className='sign-up'
+        to='/sign-up'
+        target='_blank'
+        rel='noopener noreferrer'
+      >
         Sign up
       </Link>
     </div>

--- a/src/screens/Landing/Landing.tsx
+++ b/src/screens/Landing/Landing.tsx
@@ -37,7 +37,12 @@ export const Landing: React.FC = () => {
       <div className='get-job'>
         <span>You've done the work.</span>
         <span>Get the job.</span>
-        <Link className='button' to='/sign-up'>
+        <Link
+          className='button'
+          to='/sign-up'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
           Sign up
         </Link>
       </div>

--- a/src/screens/Landing/components/Hero/Hero.tsx
+++ b/src/screens/Landing/components/Hero/Hero.tsx
@@ -18,7 +18,12 @@ export const Hero = () => {
             land the job you <span className='bold-text'>want</span>.
           </div>
         </div>
-        <Link to='/sign-up' className='hero-button'>
+        <Link
+          to='/sign-up'
+          className='hero-button'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
           Sign up
         </Link>
       </div>


### PR DESCRIPTION
This PR ensures that the user is directed to a new tab when clicking on any of the "Sign up" buttons (Links).