### PR TITLE
Refactor/bc-735 hide gihtub input for non swes

### DIFF
--- a/src/screens/Onboarding/SetUpProfile.tsx
+++ b/src/screens/Onboarding/SetUpProfile.tsx
@@ -262,17 +262,19 @@ export const SetUpProfile = ({ handlePageNavigation }) => {
                 value={links.portfolioUrl}
               />
             </label>
-            <label className='setupProfile__profile-label'>
-              GitHub (URL) Software Engineers only
-              <input
-                type='text'
-                name='githubUrl'
-                className='setupProfile__profile-input'
-                onChange={handleInputChange}
-                placeholder='myGitHubkicksass.com'
-                value={links.githubUrl}
-              />
-            </label>
+            {authUser.role === 'Software Engineer' && (
+              <label className='setupProfile__profile-label'>
+                GitHub (URL)
+                <input
+                  type='text'
+                  name='githubUrl'
+                  className='setupProfile__profile-input'
+                  onChange={handleInputChange}
+                  placeholder='myGitHubkicksass.com'
+                  value={links.githubUrl}
+                />
+              </label>
+            )}
           </div>
           <div className='setupProfile__profile-btns'>
             <div className='setupProfile__cta-container'>

--- a/src/screens/UserProfile/EditProfile.tsx
+++ b/src/screens/UserProfile/EditProfile.tsx
@@ -68,7 +68,7 @@ export const EditProfile: React.FC = () => {
       dispatch(successSnackbar('Profile saved!'))
       navigate(`/users/${params.id}`)
     } catch (error) {
-      console.log('Error occured when trying to update User Profile', error)
+      console.log('Error occurred when trying to update User Profile', error)
       dispatch(
         errorSnackbar('Failed to update user profile. Please try again.')
       )

--- a/src/screens/UserProfile/UserProfile.tsx
+++ b/src/screens/UserProfile/UserProfile.tsx
@@ -142,11 +142,11 @@ const UserInfoLinks = ({ userProfileInfo, shouldShowRole }) => {
 
   return (
     <div className='userProfile__linksContainer'>
-      <div className='userProfile__linkItem'>
-        <FiLinkedin className='userProfile__icons' />
-        <div className='userProfile__linkLast'>
-          <h3>LinkedIn</h3>
-          {shouldShowLinkedInUrl && (
+      {shouldShowLinkedInUrl && (
+        <div className='userProfile__linkItem'>
+          <FiLinkedin className='userProfile__icons' />
+          <div className='userProfile__linkLast'>
+            <h3>LinkedIn</h3>
             <a
               className='userProfile__url'
               href={userProfileInfo.links.linkedinUrl}
@@ -155,15 +155,15 @@ const UserInfoLinks = ({ userProfileInfo, shouldShowRole }) => {
             >
               {userProfileInfo.links.linkedinUrl}
             </a>
-          )}
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className='userProfile__linkItem'>
-        <TbBriefcase className='userProfile__icons' />
-        <div className='userProfile__link'>
-          <h3>Portfolio</h3>
-          {shouldShowPortfolioUrl && (
+      {shouldShowPortfolioUrl && (
+        <div className='userProfile__linkItem'>
+          <TbBriefcase className='userProfile__icons' />
+          <div className='userProfile__link'>
+            <h3>Portfolio</h3>
             <a
               className='userProfile__url'
               href={userProfileInfo.links.portfolioUrl}
@@ -172,15 +172,15 @@ const UserInfoLinks = ({ userProfileInfo, shouldShowRole }) => {
             >
               {userProfileInfo.links.portfolioUrl}
             </a>
-          )}
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className='userProfile__linkItem'>
-        <RiGithubLine className='userProfile__icons' />
-        <div className='userProfile__link'>
-          <h3>Github</h3>
-          {shouldShowGithubUrl && (
+      {shouldShowGithubUrl && (
+        <div className='userProfile__linkItem'>
+          <RiGithubLine className='userProfile__icons' />
+          <div className='userProfile__link'>
+            <h3>Github</h3>
             <a
               className='userProfile__url'
               href={userProfileInfo.links.githubUrl}
@@ -189,9 +189,9 @@ const UserInfoLinks = ({ userProfileInfo, shouldShowRole }) => {
             >
               {userProfileInfo.links.githubUrl}
             </a>
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
On the profile page of the onboarding flow the GitHub URL input will only display if the user has selected Software Engineer as their role. 

On the View Profile screen the icon and header for each URL only shows up if the user has supplied that specific URL.