### PR TITLE
bug - updated team role headers

### DIFF
--- a/src/utils/redux/slices/projectSlice.ts
+++ b/src/utils/redux/slices/projectSlice.ts
@@ -202,11 +202,11 @@ export const selectUsersById = userIds => state => {
 }
 
 export const selectMembersByRole = createSelector(
-  [selectDesignMembers, selectEngineerMembers, selectProductManagers],
+  [selectEngineerMembers, selectDesignMembers, selectProductManagers],
   (engineers, designers, productManagers) => {
     return {
-      designers,
       engineers,
+      designers,
       productManagers,
     }
   }


### PR DESCRIPTION
This PR fixes the role header bug so that engineer, designers, and product have correct role header on the Team Member page.