### PR TITLE
Bugfix/bc-788 timezone not defaulting

### DIFF
--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Timezones, weekdaysMap } from './utils/data'
 import {
   DayAvailabilityInputBanner,
@@ -12,15 +12,12 @@ import { useAppSelector } from 'utils/redux/hooks'
 import './Availability.scss'
 import { utcToBootcamprTimezoneMap } from 'utils/data/timeZoneConstants'
 import { guessUserTimezone } from 'utils/helpers/availabilityHelpers'
+import { setUserTimezone } from 'utils/redux/slices/userSlice'
 
-export const Availability = ({
-  days,
-  setDays,
-  uxUserTimezone,
-  setUxUserTimezone,
-}): JSX.Element => {
+export const Availability = ({ days, setDays }): JSX.Element => {
   const userAvailability = useAppSelector(selectUserAvailability)
   const storedUserTimezone = useAppSelector(getUserTimezone)
+  const [userFriendlyTimezone, setUserFriendlyTimezone] = useState(Timezones.ET)
 
   useEffect(() => {
     setDays(userAvailability)
@@ -28,21 +25,23 @@ export const Availability = ({
 
   useEffect(() => {
     const guessedUserTimezone = guessUserTimezone()
-    let userFriendlyTimezone = Timezones.ET
+    let timezone
 
     if (storedUserTimezone) {
-      userFriendlyTimezone = utcToBootcamprTimezoneMap[storedUserTimezone]
+      timezone = utcToBootcamprTimezoneMap[storedUserTimezone]
+      setUserFriendlyTimezone(timezone)
     } else if (guessedUserTimezone) {
-      userFriendlyTimezone = guessedUserTimezone.userFriendlyTZ
+      timezone = guessedUserTimezone.userFriendlyTZ
+      setUserFriendlyTimezone(guessedUserTimezone.userFriendlyTZ)
     }
-    setUxUserTimezone(userFriendlyTimezone)
+    setUserTimezone(timezone)
   }, [])
 
   return (
     <div className='availability-container'>
       <TimeZoneInputBanner
-        timezone={uxUserTimezone}
-        setTimezone={setUxUserTimezone}
+        timezone={userFriendlyTimezone}
+        setTimezone={setUserFriendlyTimezone}
       />
       <p>Set weekly availability</p>
       <hr />

--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -1,48 +1,23 @@
-import { useEffect, useState } from 'react'
-import { Timezones, weekdaysMap } from './utils/data'
+import { useEffect } from 'react'
+import { weekdaysMap } from './utils/data'
 import {
   DayAvailabilityInputBanner,
   TimeZoneInputBanner,
 } from './subcomponents'
-import {
-  selectUserAvailability,
-  getUserTimezone,
-} from 'utils/redux/slices/userSlice'
+import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 import { useAppSelector } from 'utils/redux/hooks'
 import './Availability.scss'
-import { utcToBootcamprTimezoneMap } from 'utils/data/timeZoneConstants'
-import { guessUserTimezone } from 'utils/helpers/availabilityHelpers'
-import { setUserTimezone } from 'utils/redux/slices/userSlice'
 
 export const Availability = ({ days, setDays }): JSX.Element => {
   const userAvailability = useAppSelector(selectUserAvailability)
-  const storedUserTimezone = useAppSelector(getUserTimezone)
-  const [userFriendlyTimezone, setUserFriendlyTimezone] = useState(Timezones.ET)
 
   useEffect(() => {
     setDays(userAvailability)
   }, [userAvailability])
 
-  useEffect(() => {
-    const guessedUserTimezone = guessUserTimezone()
-    let timezone
-
-    if (storedUserTimezone) {
-      timezone = utcToBootcamprTimezoneMap[storedUserTimezone]
-      setUserFriendlyTimezone(timezone)
-    } else if (guessedUserTimezone) {
-      timezone = guessedUserTimezone.userFriendlyTZ
-      setUserFriendlyTimezone(guessedUserTimezone.userFriendlyTZ)
-    }
-    setUserTimezone(timezone)
-  }, [])
-
   return (
     <div className='availability-container'>
-      <TimeZoneInputBanner
-        timezone={userFriendlyTimezone}
-        setTimezone={setUserFriendlyTimezone}
-      />
+      <TimeZoneInputBanner />
       <p>Set weekly availability</p>
       <hr />
       {Object.keys(weekdaysMap).map((day, idx) => (

--- a/src/components/Availability/subcomponents/TimezoneInputBanner.tsx
+++ b/src/components/Availability/subcomponents/TimezoneInputBanner.tsx
@@ -23,10 +23,9 @@ export const TimeZoneInputBanner = () => {
       timezone = utcToBootcamprTimezoneMap[storedUserTimezone]
       setUserFriendlyTimezone(timezone)
     } else if (guessedUserTimezone) {
-      timezone = guessedUserTimezone.userFriendlyTZ
-      setUserFriendlyTimezone(guessedUserTimezone.userFriendlyTZ)
+      timezone = guessedUserTimezone.userFriendly
+      setUserFriendlyTimezone(guessedUserTimezone.userFriendly)
     }
-    setUserTimezone(timezone)
   }, [])
 
   const handleChange = e => {

--- a/src/components/Availability/subcomponents/TimezoneInputBanner.tsx
+++ b/src/components/Availability/subcomponents/TimezoneInputBanner.tsx
@@ -4,15 +4,36 @@ import { Timezones } from '../utils/data'
 import { setUserTimezone } from 'utils/redux/slices/userSlice'
 import { useDispatch } from 'react-redux'
 import { bootcamprTimezoneToUTCMap } from 'utils/data/timeZoneConstants'
+import { utcToBootcamprTimezoneMap } from 'utils/data/timeZoneConstants'
+import { guessUserTimezone } from 'utils/helpers/availabilityHelpers'
+import { useEffect, useState } from 'react'
+import { useAppSelector } from 'utils/redux/hooks'
+import { getUserTimezone } from 'utils/redux/slices/userSlice'
 
-export const TimeZoneInputBanner = ({ setTimezone, timezone }) => {
+export const TimeZoneInputBanner = () => {
   const dispatch = useDispatch()
+  const storedUserTimezone = useAppSelector(getUserTimezone)
+  const [userFriendlyTimezone, setUserFriendlyTimezone] = useState(Timezones.ET)
+
+  useEffect(() => {
+    const guessedUserTimezone = guessUserTimezone()
+    let timezone
+
+    if (storedUserTimezone) {
+      timezone = utcToBootcamprTimezoneMap[storedUserTimezone]
+      setUserFriendlyTimezone(timezone)
+    } else if (guessedUserTimezone) {
+      timezone = guessedUserTimezone.userFriendlyTZ
+      setUserFriendlyTimezone(guessedUserTimezone.userFriendlyTZ)
+    }
+    setUserTimezone(timezone)
+  }, [])
 
   const handleChange = e => {
     const timezoneValue = e.target.value
     const userTZinUTC = bootcamprTimezoneToUTCMap[timezoneValue]
 
-    setTimezone(timezoneValue)
+    setUserFriendlyTimezone(timezoneValue)
     dispatch(setUserTimezone(userTZinUTC))
   }
 
@@ -20,10 +41,10 @@ export const TimeZoneInputBanner = ({ setTimezone, timezone }) => {
     <div className='timezone-input-container'>
       <h2>Availability</h2>
       <Select
-        defaultValue={timezone}
+        defaultValue={userFriendlyTimezone}
         IconComponent={ExpandMoreRounded}
         sx={tzSelectSx}
-        value={timezone}
+        value={userFriendlyTimezone}
         onChange={handleChange}
       >
         {Object.keys(Timezones).map(zone => (

--- a/src/screens/Calendar/EditAvailability.tsx
+++ b/src/screens/Calendar/EditAvailability.tsx
@@ -7,11 +7,7 @@ import { defaultAvailability } from 'utils/data/userConstants'
 import { useAppDispatch, useAppSelector } from 'utils/redux/hooks'
 import { getUserTimezone, selectAuthUser } from 'utils/redux/slices/userSlice'
 import './EditAvailability.scss'
-import { Timezones } from 'components/Availability/utils/data'
-import {
-  utcToBootcamprTimezoneMap,
-  bootcamprTimezoneToUTCMap,
-} from 'utils/data/timeZoneConstants'
+import { utcToBootcamprTimezoneMap } from 'utils/data/timeZoneConstants'
 
 export const EditAvailability = () => {
   const dispatch = useAppDispatch()
@@ -19,26 +15,18 @@ export const EditAvailability = () => {
   const userTimezoneInUTC = useAppSelector(getUserTimezone)
 
   const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
-  const [uxUserTimezone, setUxUserTimezone] = useState(Timezones.ET)
 
   const handleSaveAvailability = async () => {
-    const userTimezoneInUTC = bootcamprTimezoneToUTCMap[uxUserTimezone]
     await saveAvailability(dispatch, authUser._id, days, userTimezoneInUTC)
   }
 
   useEffect(() => {
     const userFriendlyTimezone = utcToBootcamprTimezoneMap[userTimezoneInUTC]
-    setUxUserTimezone(userFriendlyTimezone)
   }, [])
 
   return (
     <div className='edit-availability-container'>
-      <Availability
-        days={days}
-        setDays={setDays}
-        uxUserTimezone={uxUserTimezone}
-        setUxUserTimezone={setUxUserTimezone}
-      />
+      <Availability days={days} setDays={setDays} />
       <div className='edit-availability-btn-group'>
         <PrimaryButton handler={handleSaveAvailability} text='Save' />
       </div>

--- a/src/screens/Onboarding/SetupAvailability.tsx
+++ b/src/screens/Onboarding/SetupAvailability.tsx
@@ -6,12 +6,6 @@ import { getUserTimezone, selectAuthUser } from 'utils/redux/slices/userSlice'
 import { AvailabilityInterface } from 'interfaces'
 import { saveAvailability } from 'components/Availability/utils/helpers'
 import { disableForwardButton } from 'components/Availability/utils/helpers'
-import { Timezones } from 'components/Availability/utils/data'
-import { guessUserTimezone } from 'utils/helpers/availabilityHelpers'
-import {
-  utcToBootcamprTimezoneMap,
-  bootcamprTimezoneToUTCMap,
-} from 'utils/data/timeZoneConstants'
 import { PaginatorButton } from 'components/Buttons/PaginatorButtons'
 import './SetupAvailability.scss'
 
@@ -30,8 +24,7 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
   const [isDisabled, setIsDisabled] = useState(true)
 
   const storeAvailability = async () => {
-    const userTZinUTC = storedUserTZinUTC
-    await saveAvailability(dispatch, authUser._id, days, userTZinUTC)
+    await saveAvailability(dispatch, authUser._id, days, storedUserTZinUTC)
   }
 
   const handleNavigationButtons = async (direction: 'previous' | 'next') => {
@@ -40,19 +33,6 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
   }
   const handlePrevious = () => handleNavigationButtons('previous')
   const handleNext = () => handleNavigationButtons('next')
-
-  useEffect(() => {
-    let userFriendlyTZ = Timezones.ET
-    if (storedUserTZinUTC) {
-      userFriendlyTZ = utcToBootcamprTimezoneMap[storedUserTZinUTC]
-    } else {
-      const userTZguess = guessUserTimezone()
-
-      userFriendlyTZ = userFriendlyTZ
-        ? userTZguess.userFriendlyTZ
-        : Timezones.ET
-    }
-  }, [])
 
   useEffect(() => {
     const disabled = disableForwardButton(days)

--- a/src/screens/Onboarding/SetupAvailability.tsx
+++ b/src/screens/Onboarding/SetupAvailability.tsx
@@ -27,11 +27,10 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
   const storedUserTZinUTC = useAppSelector(getUserTimezone)
 
   const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
-  const [uxUserTimezone, setUxUserTimezone] = useState(Timezones.ET)
   const [isDisabled, setIsDisabled] = useState(true)
 
   const storeAvailability = async () => {
-    const userTZinUTC = bootcamprTimezoneToUTCMap[uxUserTimezone]
+    const userTZinUTC = storedUserTZinUTC
     await saveAvailability(dispatch, authUser._id, days, userTZinUTC)
   }
 
@@ -53,7 +52,6 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
         ? userTZguess.userFriendlyTZ
         : Timezones.ET
     }
-    setUxUserTimezone(userFriendlyTZ)
   }, [])
 
   useEffect(() => {
@@ -75,12 +73,7 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
           </strong>
         </i>
       </div>
-      <Availability
-        days={days}
-        setDays={setDays}
-        uxUserTimezone={uxUserTimezone}
-        setUxUserTimezone={setUxUserTimezone}
-      />
+      <Availability days={days} setDays={setDays} />
       <div className='setup-avail-buttons-wrapper'>
         <div className='setup-avail-buttons'>
           <PaginatorButton

--- a/src/utils/helpers/availabilityHelpers.ts
+++ b/src/utils/helpers/availabilityHelpers.ts
@@ -23,11 +23,11 @@ export const guessUserTimezone = () => {
     dayJSformattedTZdata[userTZ].utc
   ) {
     const utc = dayJSformattedTZdata[userTZ].utc
-    const userFriendlyTZ = utcToBootcamprTimezoneMap[utc]
+    const userFriendly = utcToBootcamprTimezoneMap[utc]
 
     return {
       utc,
-      userFriendlyTZ,
+      userFriendly,
     }
   } else {
     return undefined


### PR DESCRIPTION
In working on Availability bugs and refactoring, I noticed the timezone component wasn't managing state properly which led to controlled / uncontrolled component errors and the timezone input rendering blank rather than the guessed or stored user timezone.

This PR moves the state management of the timezone out of the parent components and into the Timezone Input Banner itself.

This resolves this bug as well: https://bootcamper.atlassian.net/browse/BC-788
