### PR TITLE
Bugfix/bc 733 improve timezone handling availability bugs

### DIFF
--- a/src/components/Availability/Availability.scss
+++ b/src/components/Availability/Availability.scss
@@ -123,6 +123,11 @@
                 margin: 0 10px;
             }
 
+            .disabled {
+                color: gray;
+                cursor:not-allowed;
+            }
+
             .react-icon {
                 cursor: pointer;
                 height: 20px;

--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -5,10 +5,12 @@ import {
 } from './subcomponents'
 import './Availability.scss'
 import { useState } from 'react'
-import { defaultAvailability } from 'utils/data/userConstants'
+import { useAppSelector } from 'utils/redux/hooks'
+import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 
 export const Availability = (): JSX.Element => {
-  const [days, setDays] = useState(defaultAvailability)
+  const storedUserAvailability = useAppSelector(selectUserAvailability)
+  const [days, setDays] = useState(storedUserAvailability)
 
   return (
     <div className='availability-container'>

--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -15,10 +15,9 @@ export const Availability = (): JSX.Element => {
       <TimeZoneInputBanner />
       <p>Set weekly availability</p>
       <hr />
-      {Object.keys(weekdaysMap).map((day, idx) => (
+      {Object.keys(weekdaysMap).map(day => (
         <DayAvailabilityInputBanner
           day={day}
-          idx={idx}
           days={days}
           setDays={setDays}
           key={`${day}-banner`}

--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -4,15 +4,25 @@ import {
   TimeZoneInputBanner,
 } from './subcomponents'
 import './Availability.scss'
+import { useState } from 'react'
+import { defaultAvailability } from 'utils/data/userConstants'
 
 export const Availability = (): JSX.Element => {
+  const [days, setDays] = useState(defaultAvailability)
+
   return (
     <div className='availability-container'>
       <TimeZoneInputBanner />
       <p>Set weekly availability</p>
       <hr />
       {Object.keys(weekdaysMap).map((day, idx) => (
-        <DayAvailabilityInputBanner day={day} idx={idx} key={`${day}-banner`} />
+        <DayAvailabilityInputBanner
+          day={day}
+          idx={idx}
+          days={days}
+          setDays={setDays}
+          key={`${day}-banner`}
+        />
       ))}
     </div>
   )

--- a/src/components/Availability/Availability.tsx
+++ b/src/components/Availability/Availability.tsx
@@ -1,33 +1,18 @@
-import { useEffect } from 'react'
 import { weekdaysMap } from './utils/data'
 import {
   DayAvailabilityInputBanner,
   TimeZoneInputBanner,
 } from './subcomponents'
-import { selectUserAvailability } from 'utils/redux/slices/userSlice'
-import { useAppSelector } from 'utils/redux/hooks'
 import './Availability.scss'
 
-export const Availability = ({ days, setDays }): JSX.Element => {
-  const userAvailability = useAppSelector(selectUserAvailability)
-
-  useEffect(() => {
-    setDays(userAvailability)
-  }, [userAvailability])
-
+export const Availability = (): JSX.Element => {
   return (
     <div className='availability-container'>
       <TimeZoneInputBanner />
       <p>Set weekly availability</p>
       <hr />
       {Object.keys(weekdaysMap).map((day, idx) => (
-        <DayAvailabilityInputBanner
-          day={day}
-          days={days}
-          idx={idx}
-          key={`${day}-banner`}
-          setDays={setDays}
-        />
+        <DayAvailabilityInputBanner day={day} idx={idx} key={`${day}-banner`} />
       ))}
     </div>
   )

--- a/src/components/Availability/subcomponents/CopyTimesModal.scss
+++ b/src/components/Availability/subcomponents/CopyTimesModal.scss
@@ -7,7 +7,7 @@
     margin: 10px;
     padding: 15px;
     position: absolute;
-    transform: translate(-8px, 20px);
+    transform: translate(0px, 29px);
     width: fit-content;
     z-index: 1;
 

--- a/src/components/Availability/subcomponents/CopyTimesModal.tsx
+++ b/src/components/Availability/subcomponents/CopyTimesModal.tsx
@@ -158,7 +158,7 @@ const CopyTimesOption = ({ day, selectedDay, checked, setChecked }) => {
         className='copy-times-option-days'
         style={{ color: 'black', width: 100, fontSize: '17px' }}
       >
-        {day}
+        {day === 'Everyday' ? 'Every Day' : day}
       </h2>
     </div>
   )

--- a/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
+++ b/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
@@ -1,8 +1,20 @@
 import { Checkbox } from '@mui/material'
 import { TimeSlotInput } from './TimeslotInput'
 import { handleCheck } from '../utils/helpers'
+import { useEffect, useState } from 'react'
+import { defaultAvailability } from 'utils/data/userConstants'
+import { AvailabilityInterface } from 'interfaces'
+import { useAppSelector } from 'utils/redux/hooks'
+import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 
-export const DayAvailabilityInputBanner = ({ day, days, idx, setDays }) => {
+export const DayAvailabilityInputBanner = ({ day, idx }) => {
+  const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
+  const userAvailability = useAppSelector(selectUserAvailability)
+
+  useEffect(() => {
+    setDays(userAvailability)
+  }, [userAvailability])
+
   return (
     <div>
       <div className='day-availability-input-banner'>

--- a/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
+++ b/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
@@ -7,9 +7,7 @@ import { AvailabilityInterface } from 'interfaces'
 import { useAppSelector } from 'utils/redux/hooks'
 import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 
-export const DayAvailabilityInputBanner = ({ day, idx }) => {
-  const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
-
+export const DayAvailabilityInputBanner = ({ day, idx, days, setDays }) => {
   useEffect(() => {
     console.log(days)
     // Set in redux here?

--- a/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
+++ b/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
@@ -1,19 +1,8 @@
 import { Checkbox } from '@mui/material'
 import { TimeSlotInput } from './TimeslotInput'
 import { handleCheck } from '../utils/helpers'
-import { useEffect, useState } from 'react'
-import { defaultAvailability } from 'utils/data/userConstants'
-import { AvailabilityInterface } from 'interfaces'
-import { useAppSelector } from 'utils/redux/hooks'
-import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 
-export const DayAvailabilityInputBanner = ({ day, idx, days, setDays }) => {
-  useEffect(() => {
-    console.log(days)
-    // Set in redux here?
-    // Also ensure that if a user already has availability stored, that should be used instead
-  }, [days])
-
+export const DayAvailabilityInputBanner = ({ day, days, setDays }) => {
   return (
     <div>
       <div className='day-availability-input-banner'>

--- a/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
+++ b/src/components/Availability/subcomponents/DayAvailabilityInputBanner.tsx
@@ -9,11 +9,12 @@ import { selectUserAvailability } from 'utils/redux/slices/userSlice'
 
 export const DayAvailabilityInputBanner = ({ day, idx }) => {
   const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
-  const userAvailability = useAppSelector(selectUserAvailability)
 
   useEffect(() => {
-    setDays(userAvailability)
-  }, [userAvailability])
+    console.log(days)
+    // Set in redux here?
+    // Also ensure that if a user already has availability stored, that should be used instead
+  }, [days])
 
   return (
     <div>

--- a/src/components/Availability/subcomponents/SelectTimeInput.tsx
+++ b/src/components/Availability/subcomponents/SelectTimeInput.tsx
@@ -12,13 +12,18 @@ export const SelectTimeInput = ({
   slot,
   days,
   setDays,
-  consolidatedDay,
+  toggleDisableAdd,
 }) => {
   const index = isStart ? 0 : 1
   const [inputTimeOptions, setInputTimeOptions] = useState(timeOptions)
   const dispatch = useDispatch()
 
   useEffect(() => {
+    if (['11:00 PM', '11:30 PM'].includes(days[day].availability[idx][index])) {
+      toggleDisableAdd(true)
+    } else {
+      toggleDisableAdd(false)
+    }
     if (!isStart) {
       const earliestLogicalOptionIndex = timeOptions.findIndex(
         timeOption => timeOption === slot[0]
@@ -28,6 +33,10 @@ export const SelectTimeInput = ({
         ...timeOptions.slice(earliestLogicalOptionIndex + 1),
       ]
       setInputTimeOptions(logicalEndOptions)
+    } else {
+      const startTimeOptions = [...timeOptions]
+      startTimeOptions.pop()
+      setInputTimeOptions(startTimeOptions)
     }
     dispatch(setUserAvailability(days))
   }, [days])
@@ -38,9 +47,7 @@ export const SelectTimeInput = ({
       inputProps={{ sx: { padding: '8px 13px !important' } }}
       MenuProps={menuPropsSX}
       name={`${day}-${idx}-${index}`}
-      onChange={e =>
-        handleTimeChange(e, days, setDays, consolidatedDay, isStart)
-      }
+      onChange={e => handleTimeChange(e, days, setDays, isStart)}
       size='small'
       sx={selectSX}
       value={days[day].availability[idx][index]}

--- a/src/components/Availability/subcomponents/SelectTimeInput.tsx
+++ b/src/components/Availability/subcomponents/SelectTimeInput.tsx
@@ -2,10 +2,21 @@ import { MenuItem, Select } from '@mui/material'
 import { timeOptions } from '../utils/data'
 import { handleTimeChange } from '../utils/helpers'
 import { useState, useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { setUserAvailability } from 'utils/redux/slices/userSlice'
 
-export const SelectTimeInput = ({ isStart, day, idx, slot, days, setDays }) => {
+export const SelectTimeInput = ({
+  isStart,
+  day,
+  idx,
+  slot,
+  days,
+  setDays,
+  consolidatedDay,
+}) => {
   const index = isStart ? 0 : 1
   const [inputTimeOptions, setInputTimeOptions] = useState(timeOptions)
+  const dispatch = useDispatch()
 
   useEffect(() => {
     if (!isStart) {
@@ -15,11 +26,10 @@ export const SelectTimeInput = ({ isStart, day, idx, slot, days, setDays }) => {
 
       const logicalEndOptions = [
         ...timeOptions.slice(earliestLogicalOptionIndex + 1),
-        timeOptions[0],
       ]
-
       setInputTimeOptions(logicalEndOptions)
     }
+    dispatch(setUserAvailability(days))
   }, [days])
 
   return (
@@ -28,7 +38,9 @@ export const SelectTimeInput = ({ isStart, day, idx, slot, days, setDays }) => {
       inputProps={{ sx: { padding: '8px 13px !important' } }}
       MenuProps={menuPropsSX}
       name={`${day}-${idx}-${index}`}
-      onChange={e => handleTimeChange(e, days, setDays)}
+      onChange={e =>
+        handleTimeChange(e, days, setDays, consolidatedDay, isStart)
+      }
       size='small'
       sx={selectSX}
       value={days[day].availability[idx][index]}

--- a/src/components/Availability/subcomponents/TimeslotInput.tsx
+++ b/src/components/Availability/subcomponents/TimeslotInput.tsx
@@ -3,8 +3,6 @@ import { FaRegTrashAlt } from 'react-icons/fa'
 import { SelectTimeInput } from './SelectTimeInput'
 import { useState, useEffect } from 'react'
 import './CopyTimesModal.scss'
-import { useDispatch } from 'react-redux'
-import { setUserAvailability } from 'utils/redux/slices/userSlice'
 import {
   consolidateAvailability,
   deleteTimeSlot,
@@ -15,21 +13,19 @@ import {
 import { weekdaysMap } from '../utils/data'
 import { BCToolTip } from 'components/ToolTip/ToolTip'
 import { CopyTimesModal } from './CopyTimesModal'
+import { useAppSelector } from 'utils/redux/hooks'
 
 export const TimeSlotInput = ({ day, days, setDays }) => {
-  const dispatch = useDispatch()
+  const [disableAdd, toggleDisableAdd] = useState(false)
   const [displayModal, toggleDisplayModal] = useState({
     0: false,
   })
-  const [consolidatedDay, setConsolidatedDay] = useState(days[day].availability)
 
   const getDisplay = idx => {
     return displayModal[idx]
   }
 
-  useEffect(() => {
-    setConsolidatedDay(days[day].availability)
-  }, [days])
+  useEffect(() => {}, [days])
 
   const handleRenderModal = (e, idx) => {
     renderCopyTimesModal(idx, displayModal, toggleDisplayModal)
@@ -37,7 +33,7 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
 
   return (
     <div className='timeslots-container'>
-      {consolidatedDay.map((slot, idx) => (
+      {days[day].availability.map((slot, idx) => (
         <div key={`${slot}-${idx}`} className='timeslot-input'>
           <div className='left-banner'>
             <SelectTimeInput
@@ -47,7 +43,7 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
               day={day}
               days={days}
               setDays={setDays}
-              consolidatedDay={consolidatedDay}
+              toggleDisableAdd={toggleDisableAdd}
             />
             <h4>--</h4>
             <SelectTimeInput
@@ -57,28 +53,37 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
               slot={slot}
               days={days}
               setDays={setDays}
-              consolidatedDay={consolidatedDay}
+              toggleDisableAdd={toggleDisableAdd}
             />
             <div className='clickable-icon'>
               <FaRegTrashAlt
                 className='react-icon'
-                onClick={() =>
-                  deleteTimeSlot(day, days, setDays, idx, consolidatedDay)
-                }
+                onClick={() => deleteTimeSlot(day, days, setDays, idx)}
               />
             </div>
           </div>
           <div className='right-banner'>
-            {consolidatedDay.length - 1 === idx && (
+            {days[day].availability.length - 1 === idx && (
               <BCToolTip
-                text={`New time block for ${weekdaysMap[day]}`}
+                text={
+                  disableAdd
+                    ? `Cannot add new time block past 11:00 PM`
+                    : `New time block for ${weekdaysMap[day]}`
+                }
                 child={
                   <div className='clickable-icon'>
                     <AddRounded
                       onClick={() =>
-                        addTimeSlot(day, days, setDays, idx, consolidatedDay)
+                        addTimeSlot(
+                          day,
+                          days,
+                          setDays,
+                          idx,
+                          disableAdd,
+                          toggleDisableAdd
+                        )
                       }
-                      className='icon'
+                      className={`icon ${disableAdd ? 'disabled' : ''}`}
                     />
                   </div>
                 }

--- a/src/components/Availability/subcomponents/TimeslotInput.tsx
+++ b/src/components/Availability/subcomponents/TimeslotInput.tsx
@@ -21,13 +21,14 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
   const [displayModal, toggleDisplayModal] = useState({
     0: false,
   })
+  const [consolidatedDay, setConsolidatedDay] = useState(days[day].availability)
 
   const getDisplay = idx => {
     return displayModal[idx]
   }
 
   useEffect(() => {
-    dispatch(setUserAvailability(days))
+    setConsolidatedDay(days[day].availability)
   }, [days])
 
   const handleRenderModal = (e, idx) => {
@@ -36,7 +37,7 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
 
   return (
     <div className='timeslots-container'>
-      {consolidateAvailability(days[day].availability).map((slot, idx) => (
+      {consolidatedDay.map((slot, idx) => (
         <div key={`${slot}-${idx}`} className='timeslot-input'>
           <div className='left-banner'>
             <SelectTimeInput
@@ -46,6 +47,7 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
               day={day}
               days={days}
               setDays={setDays}
+              consolidatedDay={consolidatedDay}
             />
             <h4>--</h4>
             <SelectTimeInput
@@ -55,22 +57,27 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
               slot={slot}
               days={days}
               setDays={setDays}
+              consolidatedDay={consolidatedDay}
             />
             <div className='clickable-icon'>
               <FaRegTrashAlt
                 className='react-icon'
-                onClick={() => deleteTimeSlot(day, days, setDays, idx)}
+                onClick={() =>
+                  deleteTimeSlot(day, days, setDays, idx, consolidatedDay)
+                }
               />
             </div>
           </div>
           <div className='right-banner'>
-            {days[day].availability.length - 1 === idx && (
+            {consolidatedDay.length - 1 === idx && (
               <BCToolTip
                 text={`New time block for ${weekdaysMap[day]}`}
                 child={
                   <div className='clickable-icon'>
                     <AddRounded
-                      onClick={() => addTimeSlot(day, days, setDays, idx)}
+                      onClick={() =>
+                        addTimeSlot(day, days, setDays, idx, consolidatedDay)
+                      }
                       className='icon'
                     />
                   </div>

--- a/src/components/Availability/subcomponents/TimeslotInput.tsx
+++ b/src/components/Availability/subcomponents/TimeslotInput.tsx
@@ -4,7 +4,6 @@ import { SelectTimeInput } from './SelectTimeInput'
 import { useState, useEffect } from 'react'
 import './CopyTimesModal.scss'
 import {
-  consolidateAvailability,
   deleteTimeSlot,
   addTimeSlot,
   renderCopyTimesModal,
@@ -13,7 +12,6 @@ import {
 import { weekdaysMap } from '../utils/data'
 import { BCToolTip } from 'components/ToolTip/ToolTip'
 import { CopyTimesModal } from './CopyTimesModal'
-import { useAppSelector } from 'utils/redux/hooks'
 
 export const TimeSlotInput = ({ day, days, setDays }) => {
   const [disableAdd, toggleDisableAdd] = useState(false)
@@ -24,10 +22,6 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
   const getDisplay = idx => {
     return displayModal[idx]
   }
-
-  useEffect(() => {
-    console.log(days)
-  }, [days])
 
   const handleRenderModal = (e, idx) => {
     renderCopyTimesModal(idx, displayModal, toggleDisplayModal)

--- a/src/components/Availability/subcomponents/TimeslotInput.tsx
+++ b/src/components/Availability/subcomponents/TimeslotInput.tsx
@@ -25,7 +25,9 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
     return displayModal[idx]
   }
 
-  useEffect(() => {}, [days])
+  useEffect(() => {
+    console.log(days)
+  }, [days])
 
   const handleRenderModal = (e, idx) => {
     renderCopyTimesModal(idx, displayModal, toggleDisplayModal)

--- a/src/components/Availability/subcomponents/TimeslotInput.tsx
+++ b/src/components/Availability/subcomponents/TimeslotInput.tsx
@@ -79,7 +79,7 @@ export const TimeSlotInput = ({ day, days, setDays }) => {
                           toggleDisableAdd
                         )
                       }
-                      className={`icon ${disableAdd ? 'disabled' : ''}`}
+                      className={`icon ${disableAdd && 'disabled'}`}
                     />
                   </div>
                 }

--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -232,10 +232,12 @@ export const deleteTimeSlot = (day, days, setDays, idx) => {
   const newAvailability = [...days[day].availability]
   newAvailability.splice(idx, 1)
 
+  const available = newAvailability.length > 0
+
   setDays({
     ...days,
     [day]: {
-      available: days[day].available,
+      available,
       availability: newAvailability,
     },
   })

--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -19,11 +19,11 @@ dayjs.extend(localizedFormat)
 export const consolidateAvailability = availability => {
   let consolidatedAvail = [...availability]
 
-  // let reducedFullLogical = createFullAvailability(consolidatedAvail)
-  //   convertLogicalToUserFriendly(reducedFullLogical)
+  let reducedFullLogical = createFullAvailability(consolidatedAvail)
+  let userFriendlyConsolidated =
+    convertLogicalToUserFriendly(reducedFullLogical)
 
-  // return userFriendlyConsolidated
-  return consolidatedAvail
+  return userFriendlyConsolidated
 }
 
 /**
@@ -142,12 +142,14 @@ export const handleTimeChange = (e, days, setDays, isStart) => {
 
   const newAvailability = [...days[day].availability]
   newAvailability[frame] = newTime
+  const consolidatedAndSortedAvailability =
+    consolidateAvailability(newAvailability)
 
   setDays({
     ...days,
     [day]: {
       available: days[day].available,
-      availability: newAvailability,
+      availability: consolidatedAndSortedAvailability,
     },
   })
 }
@@ -170,11 +172,14 @@ export const handleCheck = (day, days, setDays) => {
       ? days[day].availability
       : [['9:00 AM', '5:00 PM']]
 
+  const consolidatedAndSortedAvailability =
+    consolidateAvailability(newAvailability)
+
   setDays({
     ...days,
     [day]: {
       available,
-      availability: newAvailability,
+      availability: consolidatedAndSortedAvailability,
     },
   })
 }
@@ -275,12 +280,14 @@ export const addTimeSlot = (
     } else {
       toggleDisableAdd(false)
     }
+    const consolidatedAndSortedAvailability =
+      consolidateAvailability(newAvailability)
 
     setDays({
       ...days,
       [day]: {
         available: days[day].available,
-        availability: newAvailability,
+        availability: consolidatedAndSortedAvailability,
       },
     })
   }
@@ -359,7 +366,9 @@ export const copyTimes = (checked, day, days, idx, setDays) => {
     const storageDay = daysMap[day]
     newAvail[storageDay] = {
       available: true,
-      availability: days[storageDay].availability.concat(copiedTimeslot),
+      availability: consolidateAvailability(
+        days[storageDay].availability.concat(copiedTimeslot)
+      ),
     }
   })
 

--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -120,17 +120,11 @@ const removeDuplicates = array => {
  * @param days availability state
  * @param setDays availability state setter
  */
-export const handleTimeChange = (
-  e,
-  days,
-  setDays,
-  consolidatedDay,
-  isStart
-) => {
+export const handleTimeChange = (e, days, setDays, isStart) => {
   const context = e.target.name.split('-')
   const day = context[0]
   const frame = Number(context[1])
-  const index = context[2]
+  const index = Number(context[2])
 
   const newTime = [...days[day].availability[frame]]
   newTime[index] = e.target.value
@@ -146,7 +140,8 @@ export const handleTimeChange = (
   }
   newTime[index] = e.target.value
 
-  const newAvailability = [newTime]
+  const newAvailability = [...days[day].availability]
+  newAvailability[frame] = newTime
 
   setDays({
     ...days,
@@ -233,8 +228,17 @@ export const saveAvailability = async (
  * @param setDays
  * @param idx
  */
-export const deleteTimeSlot = (day, days, setDays, idx, consolidatedDay) => {
-  console.log('delete time slot')
+export const deleteTimeSlot = (day, days, setDays, idx) => {
+  const newAvailability = [...days[day].availability]
+  newAvailability.splice(idx, 1)
+
+  setDays({
+    ...days,
+    [day]: {
+      available: days[day].available,
+      availability: newAvailability,
+    },
+  })
 }
 
 /**
@@ -248,8 +252,36 @@ export const deleteTimeSlot = (day, days, setDays, idx, consolidatedDay) => {
  * @param setDays
  * @param idx
  */
-export const addTimeSlot = (day, days, setDays, idx, consolidatedDay) => {
-  console.log('add time slot')
+export const addTimeSlot = (
+  day,
+  days,
+  setDays,
+  idx,
+  disableAdd,
+  toggleDisableAdd
+) => {
+  if (!disableAdd) {
+    const preveiousEndTimeIndex = timeOptions.indexOf(
+      days[day].availability[idx][1]
+    )
+    const nextStartTime = timeOptions[preveiousEndTimeIndex + 1]
+    const nextTimeSlot = [nextStartTime, timeOptions[preveiousEndTimeIndex + 2]]
+    const newAvailability = [...days[day].availability, nextTimeSlot]
+
+    if (['11:00 PM', '11:30 PM'].includes(nextTimeSlot[1])) {
+      toggleDisableAdd(true)
+    } else {
+      toggleDisableAdd(false)
+    }
+
+    setDays({
+      ...days,
+      [day]: {
+        available: days[day].available,
+        availability: newAvailability,
+      },
+    })
+  }
 }
 
 /**

--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -16,14 +16,14 @@ dayjs.extend(localizedFormat)
  * @param availability (Array)
  * @returns new consolidate availability (array)
  */
-export const consolidateAvailability = (availability): string[][] => {
+export const consolidateAvailability = availability => {
   let consolidatedAvail = [...availability]
 
-  let reducedFullLogical = createFullAvailability(consolidatedAvail)
-  let userFriendlyConsolidated =
-    convertLogicalToUserFriendly(reducedFullLogical)
+  // let reducedFullLogical = createFullAvailability(consolidatedAvail)
+  //   convertLogicalToUserFriendly(reducedFullLogical)
 
-  return userFriendlyConsolidated
+  // return userFriendlyConsolidated
+  return consolidatedAvail
 }
 
 /**
@@ -120,7 +120,13 @@ const removeDuplicates = array => {
  * @param days availability state
  * @param setDays availability state setter
  */
-export const handleTimeChange = (e, days, setDays) => {
+export const handleTimeChange = (
+  e,
+  days,
+  setDays,
+  consolidatedDay,
+  isStart
+) => {
   const context = e.target.name.split('-')
   const day = context[0]
   const frame = Number(context[1])
@@ -129,9 +135,18 @@ export const handleTimeChange = (e, days, setDays) => {
   const newTime = [...days[day].availability[frame]]
   newTime[index] = e.target.value
 
-  let newAvailability = [...days[day].availability]
-  newAvailability[frame] = newTime
-  newAvailability = consolidateAvailability(newAvailability)
+  const logicalStartTime = timeOptions.indexOf(newTime[0])
+  const logicalEndTime = timeOptions.indexOf(newTime[1])
+
+  if (
+    (isStart && logicalStartTime > logicalEndTime) ||
+    logicalStartTime === logicalEndTime
+  ) {
+    newTime[1] = timeOptions[logicalStartTime + 1]
+  }
+  newTime[index] = e.target.value
+
+  const newAvailability = [newTime]
 
   setDays({
     ...days,
@@ -218,21 +233,8 @@ export const saveAvailability = async (
  * @param setDays
  * @param idx
  */
-export const deleteTimeSlot = (day, days, setDays, idx) => {
-  let newAvailability
-
-  newAvailability = {
-    available: days[day].availability.length > 1 ? true : false,
-    availability: [...days[day].availability],
-  }
-  newAvailability.availability.splice(idx, 1)
-
-  setDays({
-    ...days,
-    [day]: {
-      ...newAvailability,
-    },
-  })
+export const deleteTimeSlot = (day, days, setDays, idx, consolidatedDay) => {
+  console.log('delete time slot')
 }
 
 /**
@@ -246,27 +248,8 @@ export const deleteTimeSlot = (day, days, setDays, idx) => {
  * @param setDays
  * @param idx
  */
-export const addTimeSlot = (day, days, setDays, idx) => {
-  let nextTimeslot
-  const currentTimeslot = days[day].availability[idx][1]
-  if (currentTimeslot === '11:30 PM') {
-    nextTimeslot = ['12:00 AM', '12:30 AM']
-  } else if (currentTimeslot === '12:00 AM') {
-    nextTimeslot = ['12:30 AM', '1:00 AM']
-  } else {
-    nextTimeslot = getNextTimeslot(currentTimeslot)
-  }
-  const newAvailability = [...days[day].availability]
-
-  newAvailability.push(nextTimeslot)
-
-  setDays({
-    ...days,
-    [day]: {
-      available: days[day].available,
-      availability: newAvailability,
-    },
-  })
+export const addTimeSlot = (day, days, setDays, idx, consolidatedDay) => {
+  console.log('add time slot')
 }
 
 /**

--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -16,7 +16,7 @@ dayjs.extend(localizedFormat)
  * @param availability (Array)
  * @returns new consolidate availability (array)
  */
-export const consolidateAvailability = availability => {
+export const consolidateAvailability = (availability): string[][] => {
   let consolidatedAvail = [...availability]
 
   let reducedFullLogical = createFullAvailability(consolidatedAvail)

--- a/src/screens/Calendar/EditAvailability.tsx
+++ b/src/screens/Calendar/EditAvailability.tsx
@@ -8,12 +8,15 @@ import {
   selectUserAvailability,
 } from 'utils/redux/slices/userSlice'
 import './EditAvailability.scss'
+import { AvailabilityInterface } from 'interfaces'
 
 export const EditAvailability = () => {
   const dispatch = useAppDispatch()
   const authUser = useAppSelector(selectAuthUser)
   const userTimezoneInUTC = useAppSelector(getUserTimezone)
-  const userAvailability = useAppSelector(selectUserAvailability)
+  const userAvailability = useAppSelector<AvailabilityInterface>(
+    selectUserAvailability
+  )
 
   const handleSaveAvailability = async () => {
     await saveAvailability(

--- a/src/screens/Calendar/EditAvailability.tsx
+++ b/src/screens/Calendar/EditAvailability.tsx
@@ -15,8 +15,6 @@ export const EditAvailability = () => {
   const userTimezoneInUTC = useAppSelector(getUserTimezone)
   const userAvailability = useAppSelector(selectUserAvailability)
 
-  // const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
-
   const handleSaveAvailability = async () => {
     await saveAvailability(
       dispatch,

--- a/src/screens/Calendar/EditAvailability.tsx
+++ b/src/screens/Calendar/EditAvailability.tsx
@@ -1,32 +1,34 @@
-import { useState, useEffect } from 'react'
 import { Availability } from 'components/Availability/Availability'
 import { saveAvailability } from 'components/Availability/utils/helpers'
 import { PrimaryButton } from 'components/Buttons'
-import { AvailabilityInterface } from 'interfaces'
-import { defaultAvailability } from 'utils/data/userConstants'
 import { useAppDispatch, useAppSelector } from 'utils/redux/hooks'
-import { getUserTimezone, selectAuthUser } from 'utils/redux/slices/userSlice'
+import {
+  getUserTimezone,
+  selectAuthUser,
+  selectUserAvailability,
+} from 'utils/redux/slices/userSlice'
 import './EditAvailability.scss'
-import { utcToBootcamprTimezoneMap } from 'utils/data/timeZoneConstants'
 
 export const EditAvailability = () => {
   const dispatch = useAppDispatch()
   const authUser = useAppSelector(selectAuthUser)
   const userTimezoneInUTC = useAppSelector(getUserTimezone)
+  const userAvailability = useAppSelector(selectUserAvailability)
 
-  const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
+  // const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
 
   const handleSaveAvailability = async () => {
-    await saveAvailability(dispatch, authUser._id, days, userTimezoneInUTC)
+    await saveAvailability(
+      dispatch,
+      authUser._id,
+      userAvailability,
+      userTimezoneInUTC
+    )
   }
-
-  useEffect(() => {
-    const userFriendlyTimezone = utcToBootcamprTimezoneMap[userTimezoneInUTC]
-  }, [])
 
   return (
     <div className='edit-availability-container'>
-      <Availability days={days} setDays={setDays} />
+      <Availability />
       <div className='edit-availability-btn-group'>
         <PrimaryButton handler={handleSaveAvailability} text='Save' />
       </div>

--- a/src/screens/Onboarding/SetupAvailability.tsx
+++ b/src/screens/Onboarding/SetupAvailability.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react'
 import { Availability } from 'components/Availability/Availability'
-import { defaultAvailability } from 'utils/data/userConstants'
 import { useAppDispatch, useAppSelector } from 'utils/redux/hooks'
-import { getUserTimezone, selectAuthUser } from 'utils/redux/slices/userSlice'
-import { AvailabilityInterface } from 'interfaces'
+import {
+  getUserTimezone,
+  selectAuthUser,
+  selectUserAvailability,
+} from 'utils/redux/slices/userSlice'
 import { saveAvailability } from 'components/Availability/utils/helpers'
 import { disableForwardButton } from 'components/Availability/utils/helpers'
 import { PaginatorButton } from 'components/Buttons/PaginatorButtons'
@@ -19,8 +21,8 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
   const dispatch = useAppDispatch()
   const authUser = useAppSelector(selectAuthUser)
   const storedUserTZinUTC = useAppSelector(getUserTimezone)
+  const days = useAppSelector(selectUserAvailability)
 
-  const [days, setDays] = useState<AvailabilityInterface>(defaultAvailability)
   const [isDisabled, setIsDisabled] = useState(true)
 
   const storeAvailability = async () => {
@@ -52,7 +54,7 @@ export const SetupAvailability: React.FC<SetupAvailabilityProps> = ({
           </strong>
         </i>
       </div>
-      <Availability days={days} setDays={setDays} />
+      <Availability />
       <div className='setup-avail-buttons-wrapper'>
         <div className='setup-avail-buttons'>
           <PaginatorButton


### PR DESCRIPTION
This PR addresses various bugs in the availability component:

- 'Everyday' on the copy times modal now renders as 'Every Day'
- The plus sign to add a new time slot persists on the final time slot for a day (previously the time slots were consolidating on render, which affected whether the plus sign was visible or not)
- End time can no longer be before start time
- Logic improved to consolidate and sort time slots
- Fixed the bug where the end time slot goes blank / undefined following certain flows
- Disables the add time slot button and logic if the end time is 11:00 PM or later

NOTE: I think there is still an edge case where the second slot goes undefined - I came across it once but haven't been able to reproduce again. The majority of these cases have been resolved, but if a dev or QA is able to reproduce this bug, please take note of the steps to reproduce! If given the steps, I can address in another branch / PR