### PR TITLE
MVP 2 QA Bugfix - Availability second time slot blank

### DIFF
--- a/src/components/Availability/utils/helpers.tsx
+++ b/src/components/Availability/utils/helpers.tsx
@@ -32,6 +32,13 @@ export const consolidateAvailability = (availability): string[][] => {
 const convertLogicalToUserFriendly = (logical: number[]): string[][] => {
   let userFriendly = [timeOptions[logical[0]]]
 
+  if (logical.length === 1) {
+    const nextTime = timeOptions[logical[0] + 1]
+    userFriendly.push(nextTime)
+
+    return [userFriendly]
+  }
+
   for (let i = 1; i < logical.length; i++) {
     if (logical[i] - logical[i - 1] === 1) {
       if (i === logical.length - 1) {


### PR DESCRIPTION
The time slot consolidation logic was not properly handling the case where a time slot had a difference of only 30 minutes. This PR address that case to resolve bug # 13 in [MVP Release QA Doc](https://docs.google.com/spreadsheets/d/1KKpAXdxGiKkGNW3D5EV0jMrmqeOcoEdHr7WQDfSivNg/edit#gid=0)